### PR TITLE
fix: optimize docker-image size

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,0 @@
-*.tar filter=lfs diff=lfs merge=lfs -text
-oc.tar filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
Reduced number of layers by grouping run-commands together, makes it a little easier to use `dive` and analyze the image. Install nats-tools in the go-stage and copy them over to alpine image. No cache and dependencies taking up space. Clean up unpacked .tar.gz

In total reduced image size from 3.2GB to 1GB for now.